### PR TITLE
base: Remove unecessary instruction from start.sh

### DIFF
--- a/base/start.sh
+++ b/base/start.sh
@@ -87,7 +87,6 @@ if [ "$(id -u)" == 0 ] ; then
             mkdir "/home/${NB_USER}"
             if cp -a /home/jovyan/. "/home/${NB_USER}/"; then
                 _log "Success!"
-                rm -rf /home/jovyan
             else
                 _log "Failed to copy data from /home/jovyan to /home/${NB_USER}!"
                 _log "Attempting to symlink /home/jovyan to /home/${NB_USER}..."


### PR DESCRIPTION
This instruction was added to the file by mistake, by me. The jovyan home is changed to the NB_USER home but a symlink is created for /home/jovyan still.