### PR TITLE
base: Force versions of mamba and jupyter_core packages

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -124,8 +124,8 @@ RUN set -x && \
         --prefix="${CONDA_DIR}" \
         --yes \
         "${PYTHON_SPECIFIER}" \
-        'mamba' \
-        'jupyter_core' && \
+        'mamba=1.5.3' \
+        'jupyter_core=5.5.0' && \
     rm micromamba && \
     # Pin major.minor version of python
     mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \


### PR DESCRIPTION
The version of jupyter_core is the most recent one at this time (5.5.0). However, the version of mamba is the second most recent (1.5.3), as the most recent one (1.5.4) is preventing the image from compiling due to issues with the `mamba clean` command.