### PR TITLE
Install SwanContents v2.1.0

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -75,7 +75,7 @@ RUN tlmgr install \
 # Install all of our extensions
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS
 RUN pip install --no-deps --no-cache-dir \
-    swancontents==2.0.0 \
+    swancontents==2.1.0 \
     swanhelp==3.0.2 \
     swankernelenv==1.0.0 \
     swanoauthrenew==1.0.1  \


### PR DESCRIPTION
Contains fix for working directories of notebooks and a new lab extension to switch to the old UI.