### PR TITLE
Add slash at destination directory

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -103,7 +103,7 @@ RUN mkdir -p /usr/local/lib/swan/extensions && \
 
 # User session configuration scripts
 # Add scripts
-COPY scripts/before-notebook.d/* /usr/local/bin/before-notebook.d
+COPY scripts/before-notebook.d/* /usr/local/bin/before-notebook.d/
 
 # Grant scripts execution permissions
 RUN chmod +x /usr/local/bin/before-notebook.d/*


### PR DESCRIPTION
Otherwise COPY complains:
When using COPY with more than one source file, the destination must be a directory and end with a /