### PR TITLE
Add patch to prevent printing of tokens by Jupyter server

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -236,5 +236,12 @@ USER root
 # but not in AlmaLinux 9.
 RUN sed -i 's/CREATE_HOME.*/CREATE_HOME 0/g' /etc/login.defs
 
+# TEMPORARY: apply a patch to the auth file in JupyterHub,
+# while we wait for the release of a new version with it
+ADD patches/log_patch.diff /tmp/log_patch.diff
+RUN dnf install -y patch
+RUN patch /opt/conda/lib/python${PYTHON_VERSION}/site-packages/jupyterhub/services/auth.py /tmp/log_patch.diff && \
+    rm -f /tmp/log_patch.diff
+
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/base/patches/log_patch.diff
+++ b/base/patches/log_patch.diff
@@ -1,0 +1,12 @@
+--- ./jupyterhub/services/auth.py  2023-08-17 12:28:41.000000000 +0200
++++ ./jupyterhub/services/auth.py 2023-10-11 12:20:20.597042884 +0200
+@@ -1229,6 +1229,7 @@
+         )
+         if user_model is None:
+             raise HTTPError(500, "oauth callback failed to identify a user")
+-        app_log.info("Logged-in user %s", user_model)
++        app_log.info("Logged-in user %s", user_model['name'])
++        app_log.debug("User model %s", user_model)
+         self.hub_auth.set_cookie(self, token)
+         self.redirect(next_url or self.hub_auth.base_url)
+


### PR DESCRIPTION
While we wait for fix to be merged in (presumably) JupyterHub 4.0.3