### PR TITLE
Add patch to jupyter-server-proxy

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -116,5 +116,11 @@ ADD python/configure_kernels_and_terminal.py /srv/singleuser/configure_kernels_a
 RUN mkdir /srv/singleuser/scripts
 COPY scripts/others/* /srv/singleuser/scripts
 
+# TEMPORARY: apply a patch to the jupyter server proxy handlers,
+# while we wait for the release of a new version with it
+ADD patches/jupyter_server_proxy.diff /tmp/jupyter_server_proxy.diff
+RUN patch $(pip show jupyter-server-proxy | grep -oP 'Location: \K.*')/jupyter_server_proxy/handlers.py /tmp/jupyter_server_proxy.diff && \
+    rm -f /tmp/jupyter_server_proxy.diff
+
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/swan/patches/jupyter_server_proxy.diff
+++ b/swan/patches/jupyter_server_proxy.diff
@@ -1,0 +1,26 @@
+From 40a37b3698ab1dfa6b5688312721262008196bb5 Mon Sep 17 00:00:00 2001
+From: Diogo Castro <diogo.castro@cern.ch>
+Date: Thu, 7 Dec 2023 12:30:49 +0100
+Subject: [PATCH] Only format a proxy environment  once
+
+It was doing double formatting, which broke when passing environment variables with escaped strings (i.e {{var}}).
+---
+ jupyter_server_proxy/handlers.py | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/jupyter_server_proxy/handlers.py b/jupyter_server_proxy/handlers.py
+index db57222b..2890dc3a 100644
+--- a/jupyter_server_proxy/handlers.py
++++ b/jupyter_server_proxy/handlers.py
+@@ -654,9 +654,7 @@ def _render_template(self, value):
+     def _realize_rendered_template(self, attribute):
+         """Call any callables, then render any templated values."""
+         if callable(attribute):
+-            attribute = self._render_template(
+-                call_with_asked_args(attribute, self.process_args)
+-            )
++            attribute = call_with_asked_args(attribute, self.process_args)
+         return self._render_template(attribute)
+ 
+     @web.authenticated
+


### PR DESCRIPTION
To prevent double formatting of environment variables.

See PR upstream:
https://github.com/jupyterhub/jupyter-server-proxy/pull/437