### PR TITLE
swan: Add en langpacks required by R configuration

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -27,6 +27,9 @@ RUN dnf install -y \
     # Required for key4hep
     environment-modules \
     git \
+    # The R configuration of the LCG release requires
+    # the en_US.UTF-8 encoding
+    glibc-langpack-en \
     # Useful to monitor resource consumption
     htop \
     nano \


### PR DESCRIPTION
Install glibc-langpack-en package, as the R configuration requires the en_US.UTF-8 enconding.