### PR TITLE
swan: Remove texlive packages installation instruction

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -60,21 +60,6 @@ RUN mamba install --yes \
     'panel==1.3.4' \
     'webio-jupyter-extension==0.1.0'
 
-# Install TeX Live required packages
-RUN tlmgr install \
-    adjustbox \
-    tcolorbox \
-    environ \
-    trimspaces \
-    adjustbox \
-    collectbox \
-    ucs \
-    titling \
-    enumitem \
-    type1cm \
-    cm-super \
-    collection-fontsrecommended
-
 # Install all of our extensions
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS
 RUN pip install --no-deps --no-cache-dir \


### PR DESCRIPTION
The packages that were being installed through tlmgr (TexLive package manager) are already installed when TexLive is installed through DNF. Therefore, the instruction to install them through tlmgr is not necessary.