### PR TITLE
swan-cern: Upgrade SwanPortAllocator to v1.0.2

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -22,7 +22,7 @@ RUN pip install --no-deps --no-cache-dir dask-labextension==7.0.0
 RUN pip install --no-deps --no-cache-dir \
     sparkconnector==2.4.6 \
     sparkmonitor==2.1.1 \
-    swanportallocator==1.0.1 \
+    swanportallocator==1.0.2 \
     swandask==0.0.4
 
 # Install swandaskcluster in the lib directory that is exposed to notebooks and


### PR DESCRIPTION
Has fix to automatically enable the extension.