### PR TITLE
swan-cern: Upgrade SwanDask to v0.0.5

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install --no-deps --no-cache-dir \
     sparkconnector==2.4.6 \
     sparkmonitor==3.0.1 \
     swanportallocator==1.0.2 \
-    swandask==0.0.4
+    swandask==0.0.5
 
 # Install swandaskcluster in the lib directory that is exposed to notebooks and
 # terminals, which need it to do automatic TLS configuration for Dask clients


### PR DESCRIPTION
Fixes new naming of host_allowlist.