### PR TITLE
swan: Enforce an ipykernel version for compatibility reasons

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -103,6 +103,15 @@ RUN mkdir -p $SWAN_LIB_DIR/extensions && \
 # when the notebook starts. Check EOF of userconfig.sh
 RUN ln -s $(pip show swankernelenv | grep 'Location:' | awk '{print $2}')/swankernelenv $SWAN_LIB_DIR/extensions/
 
+# Expose ipykernel and some of its dependencies to the user environment in
+# notebooks, to enforce an ipykernel version that comes from the image,
+# instead of from the LCG release. This ensures we run the Python kernels
+# with the same package versions as the Jupyter server.
+RUN ln -s $(pip show ipykernel | grep -oP 'Location: \K.*')/ipykernel ${SWAN_LIB_DIR}/extensions/
+RUN ln -s $(pip show jupyter_core | grep -oP 'Location: \K.*')/jupyter_core ${SWAN_LIB_DIR}/extensions/
+RUN ln -s $(pip show comm | grep -oP 'Location: \K.*')/comm ${SWAN_LIB_DIR}/extensions/
+RUN ln -s $(pip show debugpy | grep -oP 'Location: \K.*')/debugpy ${SWAN_LIB_DIR}/extensions/
+
 # User session configuration scripts
 # Add scripts
 COPY scripts/before-notebook.d/* /usr/local/bin/before-notebook.d/


### PR DESCRIPTION
Before this commit, the ipykernel and dependencies were taken from the LCG release selected by the user. This has caused an incompatibility problem when upgrading Jupyter packages to be included in the new Alma9 user image.

Here we expose ipykernel and some of its dependencies to the user environment in notebooks, to enforce an ipykernel version that comes from (and is compatible with) the image, instead of from the LCG release. This ensures we run the Python kernels with the same package versions as the Jupyter server.

The reason to only symlink ipykernel and three of its dependencies is that, when installing an updated ipykernel on top of the current Bleeding edge software stack, only those packages needed to be updated -- the rest can be safely taken from the LCG release, at least with the current versions. This needs to be checked again in future updates of the user image and new LCG releases.