### PR TITLE
Disable python extensions that are not 100% operational

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -72,7 +72,6 @@ RUN mamba install --yes \
     'jupyter-server-proxy==4.1.0' \
     'jupyter-resource-usage==1.0.1' \
     # Extensions required by jupyter server
-    'panel==1.3.4' \
     'webio-jupyter-extension==0.1.0'
 
 # Install all of our extensions


### PR DESCRIPTION
This PR contains commits that disable python extensions which are not fully operational yet and require further investigation.