### PR TITLE
swan-cern: Change extension and update ipython kernel configuration file

### DIFF
--- a/swan-cern/scripts/before-notebook.d/10_spark.sh
+++ b/swan-cern/scripts/before-notebook.d/10_spark.sh
@@ -25,6 +25,17 @@ then
 
   sed -i "1s/^/c.InteractiveShellApp.extensions.append('sparkconnector.connector')\n/" \
       /home/$NB_USER/.ipython/profile_default/ipython_kernel_config.py
+
+  # Source configuration for selected cluster
+  SPARKVERSION=spark3  # Spark major version
+  HADOOPVERSION='3.3'   # Classpath compatibility for YARN
+  source $SPARK_CONFIG_SCRIPT $SPARK_CLUSTER_NAME $HADOOPVERSION $SPARKVERSION
+
+  if [[ $CONNECTOR_BUNDLED_CONFIGS ]]
+  then
+    ln -s $CONNECTOR_BUNDLED_CONFIGS/bundles.json $JUPYTER_CONFIG_DIR/nbconfig/sparkconnector_bundles.json
+    ln -s $CONNECTOR_BUNDLED_CONFIGS/spark_options.json $JUPYTER_CONFIG_DIR/nbconfig/sparkconnector_spark_options.json
+  fi
 else
   # Disable spark jupyterlab extensions enabled by default if no cluster is selected
   mkdir -p /etc/jupyter/labconfig

--- a/swan-cern/scripts/before-notebook.d/10_spark.sh
+++ b/swan-cern/scripts/before-notebook.d/10_spark.sh
@@ -28,7 +28,7 @@ then
 else
   # Disable spark jupyterlab extensions enabled by default if no cluster is selected
   mkdir -p /etc/jupyter/labconfig
-  jq -n --argjson sparkconnector true \
+  jq -n --argjson @swan-cern/sparkconnector true \
         --argjson jupyterlab_sparkmonitor true \
         '{disabledExtensions: $ARGS.named}' > /etc/jupyter/labconfig/page_config.json
   _log "Skipping Spark configuration";

--- a/swan-cern/scripts/before-notebook.d/10_spark.sh
+++ b/swan-cern/scripts/before-notebook.d/10_spark.sh
@@ -22,6 +22,9 @@ then
   _log "Globally enabling the Spark extensions"
   jq -n --argjson sparkconnector/extension true \
         '{load_extensions: $ARGS.named}' > /etc/jupyter/nbconfig/notebook.json
+
+  sed -i "1s/^/c.InteractiveShellApp.extensions.append('sparkconnector.connector')\n/" \
+      /home/$NB_USER/.ipython/profile_default/ipython_kernel_config.py
 else
   # Disable spark jupyterlab extensions enabled by default if no cluster is selected
   mkdir -p /etc/jupyter/labconfig

--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -74,6 +74,11 @@ chown -R $NB_USER:$NB_GID $LOCAL_HOME
 _log "Running user configuration script for user $NB_USER."
 sudo -E -u $NB_USER bash /srv/singleuser/scripts/userconfig.sh
 
+# Since the jupyter server is started with --preserve-env (in start.sh)
+# other variables exported from this point on are also visible in the
+# notebook/terminal environment unless overwritten by what appears in
+# the kernel.json or .bash_profile.
+
 if [ $? -ne 0 ]
 then
   _log "Error configuring user environment"


### PR DESCRIPTION
Use the correct name of the sparkconnector extension, to be disabled if spark is not being used. In addition, when spark is being used, add sparkconnector setting to ipython kernel configuration file