### PR TITLE
swan: Place npm cache in local scratch directory

### DIFF
--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -17,6 +17,9 @@ export JUPYTER_CONFIG_DIR=$JPY_DIR
 export JUPYTER_PATH=$LOCAL_HOME/.local/share/jupyter
 export JUPYTER_RUNTIME_DIR=$JUPYTER_PATH/runtime
 
+# Set npm cache on the local user home, instead of the EOS path
+export NPM_CONFIG_CACHE=$LOCAL_HOME/.npm
+
 # Set other environment variables
 export KERNEL_DIR=$JUPYTER_PATH/kernels
 export SWAN_ENV_FILE=$LOCAL_HOME/.bash_profile


### PR DESCRIPTION
Not to pollute EOS HOME dir with log files from npm and for performance sake.