### PR TITLE
Adds voms-proxy-init and links to cvmfs grid voms

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -45,8 +45,7 @@ RUN dnf install -y \
     perl-Archive-Tar \
     perl-Authen-Krb5 \
     perl-Sys-Hostname \
-    perl-Sys-Syslog \
-    voms-clients-java && \
+    perl-Sys-Syslog && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 # Required for kerberos authentication to work

--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -45,7 +45,8 @@ RUN dnf install -y \
     perl-Archive-Tar \
     perl-Authen-Krb5 \
     perl-Sys-Hostname \
-    perl-Sys-Syslog && \
+    perl-Sys-Syslog \
+    voms-clients-java && \
     dnf clean all && \
     rm -rf /var/cache/dnf
 # Required for kerberos authentication to work

--- a/swan-cern/scripts/before-notebook.d/11_htcondor.sh
+++ b/swan-cern/scripts/before-notebook.d/11_htcondor.sh
@@ -25,6 +25,13 @@ then
 
   # Ensure Dask clients call us to create a default Security object
   export DASK_DISTRIBUTED__CLIENT__SECURITY_LOADER="swandaskcluster.security.loader"
+
+  # add support for VOMS
+  if [[ -d /cvmfs/grid.cern.ch/etc ]]
+  then
+    ln -s /cvmfs/grid.cern.ch/etc/grid-security /etc/grid-security
+    ln -s /cvmfs/grid.cern.ch/etc/grid-security/vomses /etc/vomses
+  fi
 else
   _log "Skipping HTCondor configuration";
   # Disable Dask lab extension


### PR DESCRIPTION
voms-proxy-init java client

Links to /cvmfs/grid.cern.ch in the condor context (if the cvmfs is mounted)