### PR TITLE
swan-cern: Install spark extensions

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -39,6 +39,10 @@ ADD config/dask-labextension.yaml /etc/dask/labextension.yaml
 
 USER root
 
+# Install Spark extensions for classic UI
+RUN jupyter nbclassic-extension install --py --system sparkconnector && \
+    jupyter nbclassic-extension install --py --system sparkmonitor
+
 # HTCondor requirements
 RUN dnf install -y \
     # required by condor_submit


### PR DESCRIPTION
Install spark extensions for the SWAN classic UI, in order to allow users to use spark through such UI in the Alma9 image.