### PR TITLE
swan-cern: Force Alma9 Spark users to use the old UI by default

### DIFF
--- a/swan-cern/scripts/before-notebook.d/10_spark.sh
+++ b/swan-cern/scripts/before-notebook.d/10_spark.sh
@@ -12,6 +12,12 @@ then
 
   # Jupyter server configuration path
   JPY_CONFIG=$JUPYTER_CONFIG_DIR/jupyter_server_config.py
+
+  # Temporary change:
+  # Redirect user to the old UI if they select a Spark cluster on Alma9.
+  echo "" >> $JPY_CONFIG
+  echo "c.ServerApp.default_url = '/projects'" >> $JPY_CONFIG
+
   LOCAL_IP=`hostname -i`
   echo "$LOCAL_IP $SERVER_HOSTNAME" >> /etc/hosts
 


### PR DESCRIPTION
This change was introduced temporarily, before fully moving to JupyterLab and forcing all SWAN users using Alma9 to move to it as well.

When the time is right, i.e., the change to JupyterLab will take place and this commit can be reverted.