### PR TITLE
swan-cern: Create symlink to voms-proxy-init on grid.cern.ch

### DIFF
--- a/swan-cern/scripts/before-notebook.d/11_htcondor.sh
+++ b/swan-cern/scripts/before-notebook.d/11_htcondor.sh
@@ -26,11 +26,13 @@ then
   # Ensure Dask clients call us to create a default Security object
   export DASK_DISTRIBUTED__CLIENT__SECURITY_LOADER="swandaskcluster.security.loader"
 
-  # add support for VOMS
-  if [[ -d /cvmfs/grid.cern.ch/etc ]]
+  # Add support for VOMS
+  if [[ -d /cvmfs/grid.cern.ch ]]
   then
     ln -s /cvmfs/grid.cern.ch/etc/grid-security /etc/grid-security
     ln -s /cvmfs/grid.cern.ch/etc/grid-security/vomses /etc/vomses
+    # The link below should point to an alma9 voms-proxy-init when that is available
+    ln -s /cvmfs/grid.cern.ch/centos7-umd4-ui-4.0.3-1_191004/usr/bin/voms-proxy-init /usr/bin/voms-proxy-init    
   fi
 else
   _log "Skipping HTCondor configuration";


### PR DESCRIPTION
So that users can create their proxies to external data sources or the grid more easily. Using a voms-proxy-init from CVMFS also prevents the installation of the tool in the image, which we want to keep thin.

To be replaced when the corresponding Alma9 voms-proxy-init is available on /cvmfs/grid.cern.ch.