### PR TITLE
swan: Fix matplotlib plots not being interactive

### DIFF
--- a/swan-cern/scripts/before-notebook.d/10_spark.sh
+++ b/swan-cern/scripts/before-notebook.d/10_spark.sh
@@ -24,11 +24,14 @@ then
   # Enable the extensions in Jupyter global path to avoid having to maintain this information 
   # in the user scratch json file (specially because now we persist this file in the user directory and
   # we don't want to persist the Spark extensions across sessions)
-  mkdir -p /etc/jupyter/nbconfig
   _log "Globally enabling the Spark extensions"
+  # Ensure nb configuration directory is created.
+  NBCONFIG=/etc/jupyter/nbconfig/notebook.d
+  mkdir -p $NBCONFIG
+
   jq -n --argjson sparkconnector/extension true \
         --argjson sparkmonitor/extension true \
-        '{load_extensions: $ARGS.named}' > /etc/jupyter/nbconfig/notebook.json
+        '{load_extensions: $ARGS.named}' > $NBCONFIG/spark.json
 
   IPYTHON_KERNEL_CONFIG=$IPYTHONDIR/profile_default/ipython_kernel_config.py
   sed -i "1s/^/c.InteractiveShellApp.extensions.append('sparkconnector.connector')\n/" \

--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -47,6 +47,10 @@ mkdir -p $NBCONFIG
 jq -n --argjson jupyter-matplotlib/extension true \
       '{load_extensions: $ARGS.named}' > $NBCONFIG/jupyter-matplotlib.json
 
+# Enable widgets extension for classic UI
+jq -n --argjson jupyter-js-widgets/extension true \
+      '{load_extensions: $ARGS.named}' > $NBCONFIG/widgetsnbextension.json
+
 # Configure kernels and terminal
 # The environment of the kernels and the terminal will combine the view and the user script (if any)
 _log "Configuring kernels and terminal"

--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -39,6 +39,14 @@ export LCG_VIEW=$ROOT_LCG_VIEW_PATH/$ROOT_LCG_VIEW_NAME/$ROOT_LCG_VIEW_PLATFORM
 # symlink $LCG_VIEW/share/jupyter/nbextensions for the notebook extensions
 ln -s $LCG_VIEW/share/jupyter/nbextensions $JUPYTER_PATH
 
+# Create directory for nb configuration
+NBCONFIG=/etc/jupyter/nbconfig/notebook.d
+mkdir -p $NBCONFIG
+
+# Enable jupyter-matplotlib extension for classic UI
+jq -n --argjson jupyter-matplotlib/extension true \
+      '{load_extensions: $ARGS.named}' > $NBCONFIG/jupyter-matplotlib.json
+
 # Configure kernels and terminal
 # The environment of the kernels and the terminal will combine the view and the user script (if any)
 _log "Configuring kernels and terminal"


### PR DESCRIPTION
This fixes an issue with SWAN that was preventing users to use matplotlib plots in an interactive mode, by enabling the jupyter-matplotlib and widgets extensions.