### PR TITLE
ci: use image version as BUILD_TAG for SWAN images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ build_image:
     # Prepare Kaniko configuration file
     - echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
     # Build and push the image from the specified Dockerfile
-    - /kaniko/executor --context $CI_PROJECT_DIR/$IMAGE_NAME --dockerfile $CI_PROJECT_DIR/$IMAGE_NAME/Dockerfile --build-arg BUILD_TAG=$CI_COMMIT_TAG --destination $IMAGE_DESTINATION
+    - /kaniko/executor --context $CI_PROJECT_DIR/$IMAGE_NAME --dockerfile $CI_PROJECT_DIR/$IMAGE_NAME/Dockerfile --build-arg BUILD_TAG=$IMAGE_VERSION --destination $IMAGE_DESTINATION
     # Print the full registry path of the pushed image
     - echo "Image pushed successfully to ${IMAGE_DESTINATION}"
   only:


### PR DESCRIPTION
Fix issue that was being caused by using the full name of the image instead of the version tag only.