### PR TITLE
swan-cern: Add support for VOMS regardless of the usage of dask

### DIFF
--- a/swan-cern/scripts/before-notebook.d/11_htcondor.sh
+++ b/swan-cern/scripts/before-notebook.d/11_htcondor.sh
@@ -25,15 +25,6 @@ then
 
   # Ensure Dask clients call us to create a default Security object
   export DASK_DISTRIBUTED__CLIENT__SECURITY_LOADER="swandaskcluster.security.loader"
-
-  # Add support for VOMS
-  if [[ -d /cvmfs/grid.cern.ch ]]
-  then
-    ln -s /cvmfs/grid.cern.ch/etc/grid-security /etc/grid-security
-    ln -s /cvmfs/grid.cern.ch/etc/grid-security/vomses /etc/vomses
-    # The link below should point to an alma9 voms-proxy-init when that is available
-    ln -s /cvmfs/grid.cern.ch/centos7-umd4-ui-4.0.3-1_191004/usr/bin/voms-proxy-init /usr/bin/voms-proxy-init    
-  fi
 else
   _log "Skipping HTCondor configuration";
   # Disable Dask lab extension

--- a/swan-cern/scripts/before-notebook.d/12_proxy_certs.sh
+++ b/swan-cern/scripts/before-notebook.d/12_proxy_certs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Author: Ben Jones, Enric Tejedor, Pedro Maximino 2024
+# Copyright CERN
+# Adds support for the generation of VOMS proxy certificates.
+
+if [[ -d /cvmfs/grid.cern.ch ]]
+then
+    ln -s /cvmfs/grid.cern.ch/etc/grid-security /etc/grid-security
+    ln -s /cvmfs/grid.cern.ch/etc/grid-security/vomses /etc/vomses
+    # The link below should point to an alma9 voms-proxy-init when that is available
+    ln -s /cvmfs/grid.cern.ch/centos7-umd4-ui-4.0.3-1_191004/usr/bin/voms-proxy-init /usr/bin/voms-proxy-init    
+fi


### PR DESCRIPTION
There are SWAN users that require the initialization of VOMS independently of dask. Therefore, those instructions were separated and now VOMS initializes everytime a user starts their session.