### PR TITLE
swan: Prepend local python packages directory to PYTHONPATH

### DIFF
--- a/swan/scripts/others/userconfig.sh
+++ b/swan/scripts/others/userconfig.sh
@@ -46,6 +46,13 @@ export PYTHONPATH=$SWAN_LIB_DIR/extensions/:$PYTHONPATH
 # to be exposed to the user environment (notebooks, terminals)
 export PYTHONPATH=$PYTHONPATH:$SWAN_LIB_DIR/nb_term_lib/
 
+# Prepend the user site packages directory to PYTHONPATH, if they request it.
+# This allows to use Python packages installed on CERNBox
+if [ "$SWAN_USE_LOCAL_PACKAGES" == "true" ]; then
+  USER_SITE=$(python -m site --user-site)
+  export PYTHONPATH=$USER_SITE:$PYTHONPATH
+fi
+
 # Run user startup script
 TMP_SCRIPT=`mktemp`
 if [[ ! -n $USER_ENV_SCRIPT ]];


### PR DESCRIPTION
The user can select to automatically prepend the local python packages directory to the PYTHONPATH variable, thus being able to import any package installed on their CERNBox in their SWAN notebooks.
