### PR TITLE
New image for custom environments

### DIFF
--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -17,7 +17,6 @@ RUN for version in "2020.11" "2021.12" "2023.06"; do \
         chmod +x acc-py-${version}-installer.sh && \
         ./acc-py-${version}-installer.sh --installation-root ${ACCPY_PATH} && \
         rm -f acc-py-${version}-installer.sh && \
-        python -m pip install ipykernel && \
         source ${ACCPY_PATH}/base/${version}/setup.sh && \
         ${ACCPY_PATH}/base/${version}/bin/python -m ensurepip --upgrade && \
         ${ACCPY_PATH}/base/${version}/bin/pip3 install ipykernel && \
@@ -28,11 +27,6 @@ RUN dnf install -y \
     java-11-openjdk.x86_64 && \
     dnf clean all && \
     rm -rf /var/cache/dnf
-
-# Eventually, this need to be moved to swan-cern
-COPY SwanCustomEnvironments /tmp/SwanCustomEnvironments
-RUN pip install /tmp/SwanCustomEnvironments && \
-    rm -rf /tmp/SwanCustomEnvironments
 
 RUN echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
 

--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -31,4 +31,7 @@ RUN dnf install -y \
 RUN pip install --no-deps --no-cache-dir \
     swancustomenvironments==0.0.1
 
+# Jupyter notebook configuration - Add extension templates to jupyter
+RUN echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
+
 USER ${NB_UID}

--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -12,6 +12,7 @@ RUN echo "Building swan-accpy image with tag ${VERSION_DOCKER_IMAGE} from parent
 
 USER root
 
+# Install currently supported acc-py distributions
 RUN for version in "2020.11" "2021.12" "2023.06"; do \
         wget http://bewww.cern.ch/ap/acc-py/installers/acc-py-${version}-installer.sh && \
         chmod +x acc-py-${version}-installer.sh && \
@@ -23,15 +24,14 @@ RUN for version in "2020.11" "2021.12" "2023.06"; do \
         deactivate; \
     done
 
+# Install Java JDK 11
 RUN dnf install -y \
     java-11-openjdk.x86_64 && \
     dnf clean all && \
     rm -rf /var/cache/dnf
-
+# Install and configure SwanCustomEnvironments extension
 RUN pip install --no-deps --no-cache-dir \
-    swancustomenvironments==0.0.1
-
-# Jupyter notebook configuration - Add extension templates to jupyter
-RUN echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
+    swancustomenvironments==0.0.1 && \
+    echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
 
 USER ${NB_UID}

--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -1,0 +1,39 @@
+ARG VERSION_PARENT=v0.0.15
+
+FROM gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern:${VERSION_PARENT}
+
+LABEL maintainer="swan-admins@cern.ch"
+ARG NB_UID="1000"
+ARG BUILD_TAG=daily
+ENV VERSION_DOCKER_IMAGE=$BUILD_TAG
+ENV ACCPY_PATH="/opt/acc-py"
+
+RUN echo "Building swan-accpy image with tag ${VERSION_DOCKER_IMAGE} from parent tag ${VERSION_PARENT}."
+
+USER root
+
+RUN for version in "2020.11" "2021.12" "2023.06"; do \
+        wget http://bewww.cern.ch/ap/acc-py/installers/acc-py-${version}-installer.sh && \
+        chmod +x acc-py-${version}-installer.sh && \
+        ./acc-py-${version}-installer.sh --installation-root ${ACCPY_PATH} && \
+        rm -f acc-py-${version}-installer.sh && \
+        python -m pip install ipykernel && \
+        source ${ACCPY_PATH}/base/${version}/setup.sh && \
+        ${ACCPY_PATH}/base/${version}/bin/python -m ensurepip --upgrade && \
+        ${ACCPY_PATH}/base/${version}/bin/pip3 install ipykernel && \
+        deactivate; \
+    done
+
+RUN dnf install -y \
+    java-11-openjdk.x86_64 && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+# Eventually, this need to be moved to swan-cern
+COPY SwanCustomEnvironments /tmp/SwanCustomEnvironments
+RUN pip install /tmp/SwanCustomEnvironments && \
+    rm -rf /tmp/SwanCustomEnvironments
+
+RUN echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
+
+USER ${NB_UID}

--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -29,6 +29,7 @@ RUN dnf install -y \
     java-11-openjdk.x86_64 && \
     dnf clean all && \
     rm -rf /var/cache/dnf
+
 # Install and configure SwanCustomEnvironments extension
 RUN pip install --no-deps --no-cache-dir \
     swancustomenvironments==0.0.1 && \

--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION_PARENT=v0.0.15
+ARG VERSION_PARENT=v0.0.18
 
 FROM gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern:${VERSION_PARENT}
 
@@ -28,6 +28,7 @@ RUN dnf install -y \
     dnf clean all && \
     rm -rf /var/cache/dnf
 
-RUN echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
+RUN pip install --no-deps --no-cache-dir \
+    swancustomenvironments==0.0.1
 
 USER ${NB_UID}

--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -130,9 +130,11 @@ then
   exit 1
 else
   CONFIGURE_KERNEL_ENV_TIME_SEC=$(echo $(date +%s.%N --date="$START_TIME_CONFIGURE_KERNEL_ENV seconds ago") | bc)
-  software_source_name="customenv"
+  software_source_name="none"
   if [ "$SOFTWARE_SOURCE" == "lcg" ]; then
     software_source_name=${ROOT_LCG_VIEW_NAME:-none}
+  elif [ "$SOFTWARE_SOURCE" == "customenv" ]; then
+    software_source_name="customenv"
   fi
 
   _log "user: $NB_USER, host: ${SERVER_HOSTNAME%%.*}, metric: configure_kernel_env.${software_source_name}.${SPARK_CLUSTER_NAME:-none}.duration_sec, value: $CONFIGURE_KERNEL_ENV_TIME_SEC"

--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -34,7 +34,7 @@ mkdir -p $IPYTHONDIR $PROFILEPATH
 
 # Doesn't execute the script if the software source is explicitly set to customenv
 # No LCG needed, the user is responsible for providing the environment
-if [ -n "$ROOT_LCG_VIEW_NAME" ] && [ -n "$ROOT_LCG_VIEW_PLATFORM" ] && [ -n "$ROOT_LCG_VIEW_PATH" ]; then
+if [ "$SOFTWARE_SOURCE" == "lcg" ]; then
 
   # Setup the LCG View on CVMFS
   _log "Setting up environment from CVMFS"

--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -95,8 +95,6 @@ if [ "$SOFTWARE_SOURCE" == "lcg" ]; then
   then
     cp -rL $JULIA_KERNEL_PATH $KERNEL_DIR
   fi
-else
-  ROOT_LCG_VIEW_NAME="customenv"
 fi
 
 # Grant privileges to all files inside the created directories and subdirectories
@@ -132,7 +130,12 @@ then
   exit 1
 else
   CONFIGURE_KERNEL_ENV_TIME_SEC=$(echo $(date +%s.%N --date="$START_TIME_CONFIGURE_KERNEL_ENV seconds ago") | bc)
-  _log "user: $NB_USER, host: ${SERVER_HOSTNAME%%.*}, metric: configure_kernel_env.${ROOT_LCG_VIEW_NAME:-none}.${SPARK_CLUSTER_NAME:-none}.duration_sec, value: $CONFIGURE_KERNEL_ENV_TIME_SEC"
+  software_source_name="customenv"
+  if [ "$SOFTWARE_SOURCE" == "lcg" ]; then
+    software_source_name=${ROOT_LCG_VIEW_NAME:-none}
+  fi
+
+  _log "user: $NB_USER, host: ${SERVER_HOSTNAME%%.*}, metric: configure_kernel_env.${software_source_name}.${SPARK_CLUSTER_NAME:-none}.duration_sec, value: $CONFIGURE_KERNEL_ENV_TIME_SEC"
 fi
 
 # Set the terminal environment

--- a/swan/scripts/others/userconfig.sh
+++ b/swan/scripts/others/userconfig.sh
@@ -36,7 +36,7 @@ export JUPYTER_DATA_DIR=$LCG_VIEW/share/jupyter
 source $LCG_VIEW/setup.sh
 
 SETUP_LCG_TIME_SEC=$(echo $(date +%s.%N --date="$START_TIME_SETUP_LCG seconds ago") | bc)
-_log "user: $USER, host: ${SERVER_HOSTNAME%%.*}, metric: configure_user_env_cvmfs.${ROOT_LCG_VIEW_NAME:-none}.duration_sec, value: $SETUP_LCG_TIME_SEC"
+_log "user: $USER, host: ${SERVER_HOSTNAME%%.*}, metric: configure_user_env_cvmfs.${software_source_name}.duration_sec, value: $SETUP_LCG_TIME_SEC"
 
 # Prepend SWAN extensions path to PYTHONPATH to expose them
 # to the notebook processes


### PR DESCRIPTION
A new image built on top of `swan-cern` was built in order to attend the demand of Beams Department to have their `acc-py` framework distributed across SWAN for creating custom environments. For supporting this purpose, a new AccPy image was developed with:
  - 3 versions of acc-py (2020.11, 2021.12, 2023.06)
  - java11-openjdk
  - SwanCustomEnvironments configuration (temporary)

Apart from that, a small prevention for avoiding the LCG configuration made in `02_environment.sh`, in case a custom environment is launched instead of an usual LCG session.