### PR TITLE
swan-cern: Add symlink for voms-proxy-info command

### DIFF
--- a/swan-cern/scripts/before-notebook.d/12_proxy_certs.sh
+++ b/swan-cern/scripts/before-notebook.d/12_proxy_certs.sh
@@ -8,6 +8,7 @@ if [[ -d /cvmfs/grid.cern.ch ]]
 then
     ln -s /cvmfs/grid.cern.ch/etc/grid-security /etc/grid-security
     ln -s /cvmfs/grid.cern.ch/etc/grid-security/vomses /etc/vomses
-    # The link below should point to an alma9 voms-proxy-init when that is available
-    ln -s /cvmfs/grid.cern.ch/centos7-umd4-ui-4.0.3-1_191004/usr/bin/voms-proxy-init /usr/bin/voms-proxy-init    
+    # The link below should point to an alma9 voms-proxy-init and voms-proxy-info when they are available
+    ln -s /cvmfs/grid.cern.ch/centos7-umd4-ui-4.0.3-1_191004/usr/bin/voms-proxy-init /usr/bin/voms-proxy-init
+    ln -s /cvmfs/grid.cern.ch/centos7-umd4-ui-4.0.3-1_191004/usr/bin/voms-proxy-info /usr/bin/voms-proxy-info
 fi


### PR DESCRIPTION
This symlink is added per request of a user, that was being unable to find the location of the binary file for the command, to improve the user experience when using voms.