### PR TITLE
ci: Prepend the base name of the jupyter image

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set environnment package name  and version
       run: |
         IMAGE_TAG=${GITHUB_REF#refs/tags/}
-        echo "IMAGE_NAME=$(echo $IMAGE_TAG | cut -d / -f 1)" >> $GITHUB_ENV
+        echo "IMAGE_NAME=jupyter/$(echo $IMAGE_TAG | cut -d / -f 1)" >> $GITHUB_ENV
         echo "IMAGE_VERSION=$(echo $IMAGE_TAG | cut -d / -f 2)" >> $GITHUB_ENV
     
     - name: Invoke workflow in swan-charts


### PR DESCRIPTION
All of the images present in this repo always start with "jupyter" (e.g. jupyter/swan-cern). Make sure this is reflected in the CI when passing the image name.