### PR TITLE
swan: Link to frontend code of lab extensions in LCG release

### DIFF
--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -39,8 +39,9 @@ then
   _log "Setting up environment from CVMFS"
   export LCG_VIEW=$ROOT_LCG_VIEW_PATH/$ROOT_LCG_VIEW_NAME/$ROOT_LCG_VIEW_PLATFORM
 
-  # symlink $LCG_VIEW/share/jupyter/nbextensions for the notebook extensions
+  # Configure nb and lab extensions from the LCG release
   ln -s $LCG_VIEW/share/jupyter/nbextensions $JUPYTER_PATH
+  ln -s $LCG_VIEW/share/jupyter/labextensions $JUPYTER_PATH
 
   # Create directory for nb configuration
   NBCONFIG=/etc/jupyter/nbconfig/notebook.d


### PR DESCRIPTION
The LCG releases provide a directory that installs frontend files that are necessary for the interactivity of certain lab extensions. This is the case for example of matplotlib and ipywidgets.

With this commit, such directory is made visible to JupyterLab.

Fixes SWAN-155 for JupyterLab.