### PR TITLE
swan-cern: Install cronie

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -39,6 +39,9 @@ ADD config/dask-labextension.yaml /etc/dask/labextension.yaml
 
 USER root
 
+# For CVMFS prefetcher container
+RUN dnf install -y cronie
+
 # Install Spark extensions for classic UI
 RUN jupyter nbclassic-extension install --py --system sparkconnector && \
     jupyter nbclassic-extension install --py --system sparkmonitor


### PR DESCRIPTION
With the addition of cronie, the CVMFS prefetcher container of the CVMFS-CSI chart can use the same image as the user container. This is useful because we make sure that the source and python commands executed by the prefetcher run without errors in the same environment as the user (image, LCG views from CVMFS).

Note: cronie just adds a few hundreds of KB to the image.