### PR TITLE
Revert "swan-cern: Install cronie"

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -39,9 +39,6 @@ ADD config/dask-labextension.yaml /etc/dask/labextension.yaml
 
 USER root
 
-# For CVMFS prefetcher container
-RUN dnf install -y cronie
-
 # Install Spark extensions for classic UI
 RUN jupyter nbclassic-extension install --py --system sparkconnector && \
     jupyter nbclassic-extension install --py --system sparkmonitor


### PR DESCRIPTION
This reverts commit d611d2a0398cf5b346d8a3b6d8517c88c5b18763.

The prefetcher container in CVMFS-CSI will have its own image. This change was motivated by the fact that swan-cern runs by default with user jovyan, but we need it to run as root to executed crond.