### PR TITLE
prefetcher: Add prefetcher image for CVMFS

### DIFF
--- a/prefetcher/Dockerfile
+++ b/prefetcher/Dockerfile
@@ -1,0 +1,14 @@
+ARG VERSION_PARENT=v0.0.22
+
+FROM gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-cern:${VERSION_PARENT}
+
+LABEL maintainer="swan-admins@cern.ch"
+ARG BUILD_TAG=daily
+ENV VERSION_DOCKER_IMAGE=$BUILD_TAG
+
+USER root
+
+# For CVMFS prefetcher container
+RUN dnf install -y cronie && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf


### PR DESCRIPTION
This image was introduced to run the warmup jobs for the LCG releases, as the default swan-cern image runs as the jovyan user while the image needs to run as root because of cronie