### PR TITLE
Update hub version and alma9 base image tag

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitlab-registry.cern.ch/linuxsupport/alma9-base:20240501-1
+FROM gitlab-registry.cern.ch/linuxsupport/alma9-base:20240801-1
 
 LABEL maintainer="swan-admins@cern.ch"
 ARG NB_USER="jovyan"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -172,7 +172,7 @@ WORKDIR /tmp
 RUN mamba install --yes \
     'jupyterlab==4.0.7' \
     'notebook==6.5.6' \
-    'jupyterhub==4.0.2' \
+    'jupyterhub==4.1.6' \
     'nbclassic==1.0.0' && \
     jupyter server --generate-config && \
     mamba clean --all -f -y && \


### PR DESCRIPTION
Because of https://github.com/jupyterhub/jupyterhub/issues/4629.