### PR TITLE
[swan-cern] Update swan image to v0.0.16

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION_PARENT=v0.0.15
+ARG VERSION_PARENT=v0.0.16
 
 FROM gitlab-registry.cern.ch/swan/docker-images/jupyter/swan:${VERSION_PARENT}
 


### PR DESCRIPTION
Contains a fix for SwanShare and SwanContents.