### PR TITLE
[swan] Fix 02_environment.sh script

### DIFF
--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -32,78 +32,10 @@ export PROFILEPATH=$IPYTHONDIR/profile_default
 # Create missing directories
 mkdir -p $IPYTHONDIR $PROFILEPATH
 
-# Doesn't execute the script if the software source is explicitly set to customenv
-# No LCG needed, the user is responsible for providing the environment
+# Make the user the owner of the local home and subdirectories
+chown -R $NB_USER:$NB_GID $LOCAL_HOME
+
 if [ "$SOFTWARE_SOURCE" == "lcg" ]; then
-
-  # Setup the LCG View on CVMFS
-  _log "Setting up environment from CVMFS"
-  export LCG_VIEW=$ROOT_LCG_VIEW_PATH/$ROOT_LCG_VIEW_NAME/$ROOT_LCG_VIEW_PLATFORM
-
-  # symlink $LCG_VIEW/share/jupyter/nbextensions for the notebook extensions
-  ln -s $LCG_VIEW/share/jupyter/nbextensions $JUPYTER_PATH
-
-  # Setup the LCG View on CVMFS
-  _log "Setting up environment from CVMFS"
-  export LCG_VIEW=$ROOT_LCG_VIEW_PATH/$ROOT_LCG_VIEW_NAME/$ROOT_LCG_VIEW_PLATFORM
-
-  # symlink $LCG_VIEW/share/jupyter/nbextensions for the notebook extensions
-  ln -s $LCG_VIEW/share/jupyter/nbextensions $JUPYTER_PATH
-
-  # Create directory for nb configuration
-  NBCONFIG=/etc/jupyter/nbconfig/notebook.d
-  mkdir -p $NBCONFIG
-
-  # Enable jupyter-matplotlib extension for classic UI
-  jq -n --argjson jupyter-matplotlib/extension true \
-        '{load_extensions: $ARGS.named}' > $NBCONFIG/jupyter-matplotlib.json
-
-  # Enable widgets extension for classic UI
-  jq -n --argjson jupyter-js-widgets/extension true \
-        '{load_extensions: $ARGS.named}' > $NBCONFIG/widgetsnbextension.json
-
-  # Configure kernels and terminal
-  # The environment of the kernels and the terminal will combine the view and the user script (if any)
-  _log "Configuring kernels and terminal"
-
-  # ROOT
-  ROOT_KERNEL_PATH=$LCG_VIEW/etc/notebook/kernels/root
-  if [ -d $ROOT_KERNEL_PATH ];
-  then
-    cp -rL $ROOT_KERNEL_PATH $KERNEL_DIR
-  fi
-
-  # R
-  R_KERNEL_PATH=$LCG_VIEW/share/jupyter/kernels/ir
-  if [ -d $R_KERNEL_PATH ];
-  then
-    cp -rL $R_KERNEL_PATH $KERNEL_DIR
-    sed -i "s/IRkernel::main()/options(bitmapType='cairo');IRkernel::main()/g" $KERNEL_DIR/ir/kernel.json # Force cairo for graphics
-  fi
-
-  # Octave
-  OCTAVE_KERNEL_PATH=$LCG_VIEW/share/jupyter/kernels/octave
-  if [[ -d $OCTAVE_KERNEL_PATH ]];
-  then
-    cp -rL $OCTAVE_KERNEL_PATH $KERNEL_DIR
-    export OCTAVE_KERNEL_JSON=$KERNEL_DIR/octave/kernel.json
-  fi
-
-  # Julia
-  JULIA_KERNEL_PATH=$LCG_VIEW/share/jupyter/kernels/julia-*
-  if [ -d $JULIA_KERNEL_PATH ];
-  then
-    cp -rL $JULIA_KERNEL_PATH $KERNEL_DIR
-  fi
-fi
-
-  # Set other environment variables
-  export KERNEL_DIR=$JUPYTER_PATH/kernels
-  export SWAN_ENV_FILE=$LOCAL_HOME/.bash_profile
-  export PROFILEPATH=$IPYTHONDIR/profile_default
-
-  # Create missing directories
-  mkdir -p $IPYTHONDIR $PROFILEPATH
 
   # Setup the LCG View on CVMFS
   _log "Setting up environment from CVMFS"
@@ -159,9 +91,8 @@ fi
     cp -rL $JULIA_KERNEL_PATH $KERNEL_DIR
   fi
 
-  # Grant privileges to all files inside the created directories and subdirectories
-  # to the user
-  chown -R $NB_USER:$NB_GID $LOCAL_HOME
+  # Make the user the owner of kernel files
+  chown -R $NB_USER:$NB_GID $KERNEL_DIR
 
   _log "Running user configuration script for user $NB_USER."
 
@@ -203,20 +134,4 @@ fi
   echo "source $LOCAL_HOME/.bash_profile" > /etc/profile.d/swan.sh
 
   _log "Finished setting up CVMFS and user environment"
-else
-  CONFIGURE_KERNEL_ENV_TIME_SEC=$(echo $(date +%s.%N --date="$START_TIME_CONFIGURE_KERNEL_ENV seconds ago") | bc)
-  software_source_name="none"
-  if [ "$SOFTWARE_SOURCE" == "lcg" ]; then
-    software_source_name=${ROOT_LCG_VIEW_NAME:-none}
-  elif [ "$SOFTWARE_SOURCE" == "customenv" ]; then
-    software_source_name="customenv"
-  fi
-
-  _log "user: $NB_USER, host: ${SERVER_HOSTNAME%%.*}, metric: configure_kernel_env.${software_source_name}.${SPARK_CLUSTER_NAME:-none}.duration_sec, value: $CONFIGURE_KERNEL_ENV_TIME_SEC"
 fi
-
-# Set the terminal environment
-#in jupyter 6.0.0 login shell (jupyter/notebook#4112) is set by default and /etc/profile.d is respected
-echo "source $LOCAL_HOME/.bash_profile" > /etc/profile.d/swan.sh
-
-_log "Finished setting up CVMFS and user environment"


### PR DESCRIPTION
The script suffered from:
- Unmatched end of conditional block
- Repeated code blocks
- Need for change of ownership of LOCAL_HOME (custom envs case)

In addition, the emission of a custom metric for the kernel configuration time was removed when custom envs are selected, since kernels are not configured in this script in the latter case.