### PR TITLE
[swan-accpy] Update SwanCustomEnvs to v0.0.5

### DIFF
--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -32,7 +32,7 @@ RUN dnf install -y \
 
 # Install and configure SwanCustomEnvironments extension
 RUN pip install --no-deps --no-cache-dir \
-    swancustomenvironments==0.0.3
+    swancustomenvironments==0.0.5
 RUN echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
 
 USER ${NB_UID}


### PR DESCRIPTION
Has fix to see just one Python kernel.