### PR TITLE
[swan] Update jupyter-resource-usage extension to v1.1.0

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -76,7 +76,7 @@ RUN mamba install --yes \
     'voila==0.5.5' \
     'ipyparallel==8.6.1' \
     'jupyter-server-proxy==4.1.0' \
-    'jupyter-resource-usage==1.0.1' \
+    'jupyter-resource-usage==1.1.0' \
     'jupyterlab-git==0.50.0' \
     # Extensions required by jupyter server
     'webio-jupyter-extension==0.1.0' \


### PR DESCRIPTION
The current version, 1.0.1, triggers the following responses: 403 GET /user/username/api/metrics/v1

when trying to get the resource metrics in the classic UI, since the extension is not adapted to the required xsrf headers in jupyterhub v4.1.6.

Updating to v1.1.0 does not make the extension compatible with hub v4.1.6 in the classic UI, but at least it does not show anymore the 403 messages. It does not show either the Memory consumption in the classic UI, but the Lab UI is not affected.