### PR TITLE
[swan-cern] Update to swan v0.0.18

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION_PARENT=v0.0.17
+ARG VERSION_PARENT=v0.0.18
 
 FROM gitlab-registry.cern.ch/swan/docker-images/jupyter/swan:${VERSION_PARENT}
 


### PR DESCRIPTION
Contains new version of jupyter-resource-usage.