### PR TITLE
[swan-cern] Update swan image to v0.0.19

### DIFF
--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION_PARENT=v0.0.18
+ARG VERSION_PARENT=v0.0.19
 
 FROM gitlab-registry.cern.ch/swan/docker-images/jupyter/swan:${VERSION_PARENT}
 


### PR DESCRIPTION
Has a fix for the download feature (adaptation to hub v4.1.6)