### PR TITLE
swan: Cleaning up the mamba cache

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -82,7 +82,8 @@ RUN mamba install --yes \
     'webio-jupyter-extension==0.1.0' \
     # This version of pexpect is needed for
     # jupyterlab-git (0.50.0) module to work properly
-    'pexpect==4.9.0'
+    'pexpect==4.9.0' && \
+    mamba clean --all -f -y
 
 # Install all of our extensions
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS


### PR DESCRIPTION
This is done to avoid keeping `/opt/conda/pkgs` alive, in order to keep mamba warning messages away from the user when creating mamba custom environments