### PR TITLE
swan-accpy: Install `uv` package manager

### DIFF
--- a/swan-accpy/Dockerfile
+++ b/swan-accpy/Dockerfile
@@ -35,4 +35,9 @@ RUN pip install --no-deps --no-cache-dir \
     swancustomenvironments==0.0.18
 RUN echo -e '\nc.ServerApp.extra_template_paths = ["/opt/conda/lib/python3.11/site-packages/swancustomenvironments/templates/"]' >> /home/${NB_USER}/.jupyter/jupyter_server_config.py
 
+# Install UV for faster package installation
+RUN export XDG_BIN_HOME=/usr/local/bin && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh -s -- --no-modify-path && \
+    chmod u+x $XDG_BIN_HOME/uv
+
 USER ${NB_UID}


### PR DESCRIPTION
UV is useful for replacing pip when installing requirements on accpy custom environments