### PR TITLE
Run jupyterhub singleuser isolated

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -254,5 +254,11 @@ RUN patch /opt/conda/lib/python${PYTHON_VERSION}/site-packages/jupyterhub/servic
 # - https://discourse.jupyter.org/t/debugger-warning-it-seems-that-frozen-modules-are-being-used-python-3-11-0/16544/5
 ENV PYDEVD_DISABLE_FILE_VALIDATION=1
 
+# By default, prevent the lookup of Python modules in the user site by:
+# - The Jupyter server
+# - Python notebook processes
+# - Python processes created in the terminal
+ENV PYTHONNOUSERSITE=1
+
 # Switch back to jovyan to avoid accidental container runs as root
 USER ${NB_UID}

--- a/base/start.sh
+++ b/base/start.sh
@@ -143,6 +143,7 @@ if [ "$(id -u)" == 0 ] ; then
         LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" \
         PATH="${PATH}" \
         PYTHONPATH="${PYTHONPATH:-}" \
+        PYTHONNOUSERSITE="1" \
         "${cmd[@]}"
         # Notes on how we ensure that the environment that this container is started
         # with is preserved (except vars listed in JUPYTER_ENV_VARS_TO_UNSET) when

--- a/swan/config/kernel.json
+++ b/swan/config/kernel.json
@@ -3,7 +3,6 @@
     "language": "python",
     "argv": [
      "python",
-     "-s",
      "-m",
      "ipykernel",
      "-f",


### PR DESCRIPTION
Start the singleuser server without taking into account the packages the user has installed in their EOS, as they may conflict with the setup of the server due to older versions, etc.