### PR TITLE
ci: Specify which tags trigger the workflow

### DIFF
--- a/.github/workflows/cascade-image-update.yaml
+++ b/.github/workflows/cascade-image-update.yaml
@@ -3,7 +3,9 @@ name: Update Child Images
 on:
   push:
     tags:
-      - '*'
+    - base/*
+    - swan/*
+    - swan-cern/*
 
 jobs:
   update-dockerfiles:


### PR DESCRIPTION
Only activate the workflow when specific tags are pushed to the repo, related to the user images