### PR TITLE
ci: Checkout main branch always

### DIFF
--- a/.github/workflows/cascade-image-update.yaml
+++ b/.github/workflows/cascade-image-update.yaml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+      with:
+        ref: main
 
     - name: Set Up Git
       run: |


### PR DESCRIPTION
Checkout the main branch when running the CI to update the images versions on cascade