### PR TITLE
swan: Set PIP_TARGET env variable

### DIFF
--- a/swan/scripts/others/userconfig.sh
+++ b/swan/scripts/others/userconfig.sh
@@ -48,10 +48,15 @@ export PYTHONPATH=$PYTHONPATH:$SWAN_LIB_DIR/nb_term_lib/
 
 # Prepend the user site packages directory to PYTHONPATH, if they request it.
 # This allows to use Python packages installed on CERNBox
+USER_SITE=$(python -m site --user-site)
 if [ "$SWAN_USE_LOCAL_PACKAGES" == "true" ]; then
-  USER_SITE=$(python -m site --user-site)
   export PYTHONPATH=$USER_SITE:$PYTHONPATH
 fi
+
+# This variable is defined to automatically install user
+# python packages in their CERNBox, without them having
+# to add the "--user" flag to the pip installation command
+export PIP_TARGET=$USER_SITE
 
 # Run user startup script
 TMP_SCRIPT=`mktemp`


### PR DESCRIPTION
Set this variable with the path of the Python packages on the user EOS so that the user does not need to add the --user flag to the pip command every time they want to install a package in their CERNBox