### PR TITLE
Revert "swan: Set PIP_TARGET env variable"

### DIFF
--- a/swan/scripts/others/userconfig.sh
+++ b/swan/scripts/others/userconfig.sh
@@ -48,15 +48,10 @@ export PYTHONPATH=$PYTHONPATH:$SWAN_LIB_DIR/nb_term_lib/
 
 # Prepend the user site packages directory to PYTHONPATH, if they request it.
 # This allows to use Python packages installed on CERNBox
-USER_SITE=$(python -m site --user-site)
 if [ "$SWAN_USE_LOCAL_PACKAGES" == "true" ]; then
+  USER_SITE=$(python -m site --user-site)
   export PYTHONPATH=$USER_SITE:$PYTHONPATH
 fi
-
-# This variable is defined to automatically install user
-# python packages in their CERNBox, without them having
-# to add the "--user" flag to the pip installation command
-export PIP_TARGET=$USER_SITE
 
 # Run user startup script
 TMP_SCRIPT=`mktemp`


### PR DESCRIPTION
This reverts commit 6cd7b28f087ec8e256017162da74b5e1bd99c5b2.

When a user uses --user flag, pip errors out as we already force the usage of the --target flag with the PIP_TARGET variable. Moreover, when a session is started with custom environments, the packages should not be installed by default in the user CERNBox (i.e. in the site-packages in their CERNBox).