### PR TITLE
swan: Update `jupyterlab-git` version to `0.51.1`

### DIFF
--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -77,12 +77,9 @@ RUN mamba install --yes \
     'ipyparallel==8.6.1' \
     'jupyter-server-proxy==4.1.0' \
     'jupyter-resource-usage==1.1.0' \
-    'jupyterlab-git==0.50.0' \
+    'jupyterlab-git==0.51.1' \
     # Extensions required by jupyter server
-    'webio-jupyter-extension==0.1.0' \
-    # This version of pexpect is needed for
-    # jupyterlab-git (0.50.0) module to work properly
-    'pexpect==4.9.0'
+    'webio-jupyter-extension==0.1.0'
 
 # Install all of our extensions
 # Ignore (almost all) dependencies because they have already been installed or come from CVMFS


### PR DESCRIPTION
`pexepect` didn't work with Python 3.11. With this update, that got fixed