### PR TITLE
swan: Use custom PDFExporter command to reduce PDF export time

### DIFF
--- a/swan/python/jupyter_server_config.py
+++ b/swan/python/jupyter_server_config.py
@@ -30,3 +30,9 @@ if use_jupyterlab:
     c.ServerApp.default_url = '/lab'
 else:
     c.ServerApp.default_url = '/projects'
+
+user = os.environ.get('USER')
+# Change the HOME environment variable to the local user home instead of EOS
+# to prevent xelatex from touching EOS during the PDF conversion and so
+# reduce the time it takes to convert a PDF (including preventing timeouts).
+c.PDFExporter.latex_command = ['env', f'HOME=/home/{user}' , 'xelatex', '-quiet', '{filename}']


### PR DESCRIPTION
Force the PDF exporter command to use the temporary user home, to prevent it touching the user EOS and with that reduce the time it takes for a notebook to be exported to PDF