### PR TITLE
swan: Force the git command to run locally

### DIFF
--- a/swan/scripts/before-notebook.d/02_environment.sh
+++ b/swan/scripts/before-notebook.d/02_environment.sh
@@ -36,7 +36,8 @@ mkdir -p $IPYTHONDIR $PROFILEPATH
 # This will hide the checkpoint files created by EOS.
 GLOBAL_GITIGNORE="$LOCAL_HOME/.gitignore_global"
 echo ".sys.*" > "$GLOBAL_GITIGNORE"
-run_as_user git config --global core.excludesfile "$GLOBAL_GITIGNORE"
+# Set HOME to LOCAL_HOME to prevent git from internally touching EOS
+run_as_user HOME=$LOCAL_HOME git config --global core.excludesfile "$GLOBAL_GITIGNORE"
 
 # Make the user the owner of the local home and subdirectories
 chown -R $NB_USER:$NB_GID $LOCAL_HOME


### PR DESCRIPTION
The git command is supposed to touch the local user home in the container instead of EOS, when adding the git configuration file