### PR TITLE
swan: [SWAN-410] Allow editable packages to be found by Python

### DIFF
--- a/swan/scripts/others/userconfig.sh
+++ b/swan/scripts/others/userconfig.sh
@@ -51,6 +51,7 @@ export PYTHONPATH=$PYTHONPATH:$SWAN_LIB_DIR/nb_term_lib/
 if [ "$SWAN_USE_LOCAL_PACKAGES" == "true" ]; then
   USER_SITE=$(python -m site --user-site)
   export PYTHONPATH=$USER_SITE:$PYTHONPATH
+  export PYTHONNOUSERSITE=0 # allow editable packages to be found by Python
 fi
 
 # Run user startup script


### PR DESCRIPTION
PYTHONNOUSERSITE is set to 1 in the base image to prevent the Jupyter server process, notebook processes and terminal processes from inspecting the user site packages directory by default.

However, if PYTHONNOUSERSITE is set to 1, editable packages are ignored by Python (see SWAN-410 for more details). Therefore, if the user selects to work with packages installed on CERNBox (editable or not), we unset PYTHONNOUSERSITE to prevent breaking the editable package search mechanism.