### PR TITLE
ci: Update all swan images in the charts, when there are new tags

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -3,7 +3,7 @@ name: Bump version of swan-cern in other repositories
 on:
   push:
     tags:
-    - swan-cern/*
+    - swan*
 
 jobs:
   build-publish:


### PR DESCRIPTION
This is to update the swan image in the swan chart, swan-cern and swan-accpy images in the swan-cern chart, so that all images are up to date