### PR TITLE
ci: List only the tags of the images defined in the charts

### DIFF
--- a/.github/workflows/update-images.yaml
+++ b/.github/workflows/update-images.yaml
@@ -3,7 +3,9 @@ name: Bump version of swan-cern in other repositories
 on:
   push:
     tags:
-    - swan*
+    - swan/*
+    - swan-cern/*
+    - swan-accpy/*
 
 jobs:
   build-publish:


### PR DESCRIPTION
Be more selective on the images that should trigger this pipeline, as not all future images prefixed with swan name may be part of the swan-charts