### PR TITLE
swan/swan-cern: Upgrade image python packages to latest versions

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM gitlab-registry.cern.ch/linuxsupport/alma9-base:20240801-1
+FROM gitlab-registry.cern.ch/linuxsupport/alma9-base:20260205-1
 
 LABEL maintainer="swan-admins@cern.ch"
 ARG NB_USER="jovyan"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -123,7 +123,7 @@ RUN set -x && \
         --yes \
         "${PYTHON_SPECIFIER}" \
         'mamba=1.5.3' \
-        'jupyter_core=5.5.0' && \
+        'jupyter_core=5.9.1' && \
     rm micromamba && \
     # Pin major.minor version of python
     mamba list python | grep '^python ' | tr -s ' ' | cut -d ' ' -f 1,2 >> "${CONDA_DIR}/conda-meta/pinned" && \
@@ -164,16 +164,12 @@ USER ${NB_UID}
 # Do all this in a single RUN command to avoid duplicating all of the
 # files across image layers when the permissions change
 # Force the current latest versions of the python packages installed
-# in the SWAN base image, except for the notebook one. This package
-# is using the latest version (6.5.6) before major version 7, as there
-# are incompatibility issues that arise due to the usage of such
-# version along with the package nbclassic or swanclassic.
+# in the SWAN base image.
 WORKDIR /tmp
 RUN mamba install --yes \
-    'jupyterlab==4.0.7' \
-    'notebook==6.5.6' \
+    'jupyterlab==4.5.6' \
     'jupyterhub==5.4.3' \
-    'nbclassic==1.0.0' && \
+    'nbclassic==1.3.3' && \
     jupyter server --generate-config && \
     mamba clean --all -f -y && \
     npm cache clean --force && \

--- a/swan-cern/Dockerfile
+++ b/swan-cern/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="swan-admins@cern.ch"
 ARG NB_UID="1000"
 ARG BUILD_TAG=daily
 ENV VERSION_DOCKER_IMAGE=$BUILD_TAG
-ENV RUCIO_JUPYTERLAB_VERSION="1.4.1"
+ENV RUCIO_JUPYTERLAB_VERSION="40.0.2"
 
 RUN echo "Building swan-cern image with tag ${VERSION_DOCKER_IMAGE} from parent tag ${VERSION_PARENT}."
 

--- a/swan/Dockerfile
+++ b/swan/Dockerfile
@@ -76,11 +76,11 @@ RUN pip install --no-deps --no-cache-dir \
 
 # Install python pip packages
 RUN mamba install --yes \
-    'voila==0.5.5' \
-    'ipyparallel==8.6.1' \
+    'voila==0.5.11' \
+    'ipyparallel==9.0.2' \
     'jupyter-server-proxy==4.4.0' \
-    'jupyter-resource-usage==1.1.0' \
-    'jupyterlab-git==0.51.1' \
+    'jupyter-resource-usage==1.2.0' \
+    'jupyterlab-git==0.51.4' \
     # Extensions required by jupyter server
     'webio-jupyter-extension==0.1.0'
 


### PR DESCRIPTION
This upgrades most of the Python packages used by the user image to their latest versions to support new available features, remove deprecrated ones and fix security vulnerabilities.

This PR depends on #260 and the new version of the Rucio extension (1.5.0) once it is released.