### PR TITLE
Build swan-accpy on GitLab

### DIFF
--- a/.github/workflows/_release-image.yml
+++ b/.github/workflows/_release-image.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: boolean
         default: false
+      skip-build:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -62,6 +66,7 @@ jobs:
           gh release create "$NEW_TAG" --notes "$NOTES"
 
   build-and-push:
+    if: ${{ !inputs.skip-build }}
     runs-on: ubuntu-latest
     needs: release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
     uses: ./.github/workflows/_release-image.yml
     with:
       image: swan-accpy
-      notify-swan-charts: true
+      skip-build: true  # Built on GitLab CI (needs CERN network for acc-py installers)
     secrets: inherit
 
   release-prefetcher:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,43 @@
+# swan-accpy is built on GitLab CI because it needs CERN network access
+# to both download and install the Acc-Py release.
+#
+# This pipeline is triggered when a swan-accpy/v* tag is mirrored from GitHub.
+
+stages:
+  - build
+  - notify
+
+variables:
+  IMAGE_NAME: gitlab-registry.cern.ch/swan/docker-images/jupyter/swan-accpy
+
+build-swan-accpy:
+  stage: build
+  image: quay.io/buildah/stable:latest
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^swan-accpy\/v.+$/
+  script:
+    - VERSION=${CI_COMMIT_TAG#swan-accpy/}
+    - buildah login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+    - buildah build
+      --storage-driver vfs
+      --build-arg "BUILD_TAG=${VERSION}"
+      -t "${IMAGE_NAME}:${VERSION}"
+      swan-accpy
+    - buildah push --storage-driver vfs "${IMAGE_NAME}:${VERSION}"
+
+notify-swan-charts:
+  stage: notify
+  image: alpine:latest
+  needs: [build-swan-accpy]
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^swan-accpy\/v.+$/
+  script:
+    - VERSION=${CI_COMMIT_TAG#swan-accpy/}
+    - apk add --no-cache curl
+    - >-
+      curl -L -X POST
+      -H "Accept: application/vnd.github+json"
+      -H "Authorization: Bearer ${GITHUB_TOKEN}"
+      -H "X-GitHub-Api-Version: 2026-03-10"
+      https://api.github.com/repos/swan-cern/swan-charts/actions/workflows/update-images.yaml/dispatches
+      -d "{\"ref\":\"master\",\"inputs\":{\"image\":\"jupyter/swan-accpy\",\"version\":\"${VERSION}\"}}"


### PR DESCRIPTION
swan-accpy needs to download and install the Acc-Py releases which require access to the CERN internal network.