### PR TITLE
Fix CI for extensions which have different PyPI names

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -26,6 +26,10 @@ jobs:
     - name: Update package version
       run: |
         PKG_NAME_LOWER=$(echo " ${{ inputs.package }}" | tr '[:upper:]' '[:lower:]')
+        # Some packages have different names on PyPI
+        if [[ "$PKG_NAME_LOWER" == "swanmarimoproxy" ]]; then
+          PKG_NAME_LOWER="swan-marimo-proxy"
+        fi
         PKG_VER=$(echo "${{ inputs.version }}" | sed -e "s/v//g")
 
         for DIR in base swan swan-cern; do


### PR DESCRIPTION
The current assumption is that the folder name in jupyter-extensions matches the PyPI package name. For marimo, I went with dashes to make the name easier to read: `swan-marimo-proxy`. This unfrotunately does not work with since it tries to bump a package named `swanmarimoproxy` which does not exist. This may not be the nicest way, but I'd say the simplest. I would prefer not to rename the PyPI package because `swanmarimoproxy` is impossible to read :laughing: 