### PR TITLE
ci: Remove 'persist-credentials'

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -30,7 +30,6 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: master
-        persist-credentials: false
 
     - name: Update package version
       run: |


### PR DESCRIPTION
We need the credentials here since we are pushing to a branch in the following step.