### PR TITLE
ci: Fix workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
   release-base:
     if: inputs.image == 'base'
     uses: ./.github/workflows/_release-image.yml
+    permissions:
+      contents: write # Required by the nested workflow
     with:
       image: base
       children: swan
@@ -38,6 +40,8 @@ jobs:
       contains(fromJSON('["base", "swan"]'), inputs.image)
     needs: release-base
     uses: ./.github/workflows/_release-image.yml
+    permissions:
+      contents: write # Required by the nested workflow
     with:
       image: swan
       children: swan-cern
@@ -52,6 +56,8 @@ jobs:
       contains(fromJSON('["base", "swan", "swan-cern"]'), inputs.image)
     needs: release-swan
     uses: ./.github/workflows/_release-image.yml
+    permissions:
+      contents: write # Required by the nested workflow
     with:
       image: swan-cern
       children: "swan-accpy prefetcher"
@@ -66,6 +72,8 @@ jobs:
       contains(fromJSON('["base", "swan", "swan-cern", "swan-accpy"]'), inputs.image)
     needs: release-swan-cern
     uses: ./.github/workflows/_release-image.yml
+    permissions:
+      contents: write # Required by the nested workflow
     with:
       image: swan-accpy
       skip-build: true  # Built on GitLab CI (needs CERN network for acc-py installers)
@@ -79,6 +87,8 @@ jobs:
       contains(fromJSON('["base", "swan", "swan-cern", "prefetcher"]'), inputs.image)
     needs: release-swan-cern
     uses: ./.github/workflows/_release-image.yml
+    permissions:
+      contents: write # Required by the nested workflow
     with:
       image: prefetcher
     secrets:


### PR DESCRIPTION
We have this error currently: https://github.com/swan-cern/jupyter-images/actions/runs/25370133159

Looks like a regression from https://github.com/swan-cern/jupyter-images/pull/322