### PR TITLE
swan: Only set preferred_dir for JupyterLab

### DIFF
--- a/swan/python/jupyter_server_config.py
+++ b/swan/python/jupyter_server_config.py
@@ -4,19 +4,20 @@ home = os.environ.get("HOME")
 jupyter_path = os.environ.get("JUPYTER_PATH", f"{home}/.local/share/jupyter")
 eos_enabled = os.environ.get("EOS_ENABLED", "true").lower() == "true"
 local_home = os.environ.get("LOCAL_HOME", "false").lower() == "true"
+use_jupyterlab = os.environ.get('SWAN_USE_JUPYTERLAB', 'false').lower() == 'true'
 
 c.NotebookNotary.db_file = f"{jupyter_path}/nbsignatures.db"
 c.NotebookNotary.secret_file = f"{jupyter_path}/notebook_secret"
 
-# Configure jupyter lab start directory
-if eos_enabled and not local_home:
-    # The most common case: EOS is enabled and user home is "/eos/user/<letter>/<username>"
+# Configure start directory
+if eos_enabled and not local_home and use_jupyterlab:
+    # Case 1: JupyterLab with EOS enabled and user home is "/eos/user/<letter>/<username>"
     # In this case, set the root_dir to "/eos" and the preferred_dir to the user home,
     # so that the user sees their home when they open Jupyter but can also easily navigate to other parts of EOS.
     c.ServerApp.root_dir = '/eos'
     c.FileContentsManager.preferred_dir = home
 else:
-    # The less common case: either EOS is disabled or $HOME is not on EOS
+    # Case 2: Either classic UI is selected, EOS is disabled or $HOME is not on EOS
     # In this case, just set the root_dir to the user home.
     c.ServerApp.root_dir = home
 
@@ -40,7 +41,6 @@ if eos_enabled:
     ])
 
 # Toggle JupyterLab based on user preference
-use_jupyterlab = os.environ.get('SWAN_USE_JUPYTERLAB', 'false').lower() == 'true'
 if use_jupyterlab or not eos_enabled:
     c.ServerApp.default_url = '/lab'
 else:


### PR DESCRIPTION
The old UI does not like it when the root dir is not `$HOME` (getting a 404). In any case, it only makes sense to enable this for lab since there is no UI affordance in the old UI to take advantage of it anyway.